### PR TITLE
Fix duplicate GetDocumentAnalysis reference

### DIFF
--- a/doc_source/API_GetDocumentAnalysis.md
+++ b/doc_source/API_GetDocumentAnalysis.md
@@ -147,7 +147,7 @@ Amazon Textract experienced a service issue\. Try your call again\.
 HTTP Status Code: 500
 
  **InvalidJobIdException**   
-An invalid job identifier was passed to [GetDocumentAnalysis](#API_GetDocumentAnalysis) or to [GetDocumentAnalysis](#API_GetDocumentAnalysis)\.  
+An invalid job identifier was passed to [GetDocumentAnalysis](#API_GetDocumentAnalysis) or to [GetDocumentTextDetection](API_GetDocumentTextDetection.md)\.  
 HTTP Status Code: 400
 
  **InvalidParameterException**   

--- a/doc_source/API_GetDocumentTextDetection.md
+++ b/doc_source/API_GetDocumentTextDetection.md
@@ -144,7 +144,7 @@ Amazon Textract experienced a service issue\. Try your call again\.
 HTTP Status Code: 500
 
  **InvalidJobIdException**   
-An invalid job identifier was passed to [GetDocumentAnalysis](API_GetDocumentAnalysis.md) or to [GetDocumentAnalysis](API_GetDocumentAnalysis.md)\.  
+An invalid job identifier was passed to [GetDocumentAnalysis](API_GetDocumentAnalysis.md) or to [GetDocumentTextDetection](API_GetDocumentTextDetection.md)\.
 HTTP Status Code: 400
 
  **InvalidParameterException**   


### PR DESCRIPTION
*Issue #, if available:*
InvalidJobIdException can be passed to GetDocumentTextDetection too. GetDocumentAnalysis was referenced twice

*Description of changes:*
replace duplicated GetDocumentAnalysis with GetDocumentTextDetection


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
