### PR TITLE
Errata Changed ColumnSpan to RowSpan

### DIFF
--- a/doc_source/detecting-document-text.md
+++ b/doc_source/detecting-document-text.md
@@ -273,10 +273,10 @@ You can provide an input document as an image byte array \(base64\-encoded image
    
        if block['BlockType'] == 'CELL':
            print("    Cell information")
-           print("        Column:" + str(block['ColumnIndex']))
-           print("        Row:" + str(block['RowIndex']))
-           print("        Column Span:" + str(block['ColumnSpan']))
-           print("        RowSpan:" + str(block['ColumnSpan']))    
+           print("        Column: " + str(block['ColumnIndex']))
+           print("        Row: " + str(block['RowIndex']))
+           print("        Column Span: " + str(block['ColumnSpan']))
+           print("        RowSpan: " + str(block['RowSpan']))    
        
        if 'Relationships' in block:
            print('    Relationships: {}'.format(block['Relationships']))


### PR DESCRIPTION
Python code previously was         print("         RowSpan:" + str(block['ColumnSpan']))
This has been updated to display RowSpan. 
An extra space has been added after the colon for readability.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
